### PR TITLE
Hotfix: Fix ESBuild not installing & add postinstall run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
     "name": "dreamland-router",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "",
     "keywords": [],
     "author": "coolelectronics",
     "scripts": {
         "build": "rollup -c",
-        "watch": "rollup -cw"
+        "watch": "rollup -cw",
+        "postinstall": "npm run build"
     },
     "type": "module",
     "license": "LGPL-3.0",
@@ -20,7 +21,7 @@
     "types": "dist/index.d.ts",
     "devDependencies": {
         "dreamland": "^0.0.10",
-        "esbuild": "^0.20.0",
+        "esbuild": "^0.20.2",
         "esbuild-plugin-d.ts": "^1.2.3",
         "rollup": "^4.11.0",
         "rollup-plugin-typescript2": "^0.36.0"


### PR DESCRIPTION
Basic PR, Fixes issue with ESBuild where when installing it would return the error below & add postinstall script to auto run build when installing.

│ node:internal/errors:865
│   const err = new Error(message);
│               ^
│ Error: Command failed: E:\Apps\NodeJS\node.exe E:\Files\sodium-alice\node_modules\.pnpm\github.com+MercuryWorkshop+…
│ node:child_process:924
│     throw err;
│     ^
│ <ref *1> Error: spawnSync E:\Files\sodium-alice\node_modules\.pnpm\github.com+MercuryWorkshop+dreamland-router@017f…
│     at Object.spawnSync (node:internal/child_process:1110:20)
│     at spawnSync (node:child_process:871:24)
│     at Object.execFileSync (node:child_process:914:15)
│     at Object.<anonymous> (E:\Files\sodium-alice\node_modules\.pnpm\github.com+MercuryWorkshop+dreamland-router@017…
│     at Module._compile (node:internal/modules/cjs/loader:1256:14)
│     at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
│     at Module.load (node:internal/modules/cjs/loader:1119:32)
│     at Module._load (node:internal/modules/cjs/loader:960:12)
│     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
│     at node:internal/main/run_main_module:23:47 {
│   errno: -4058,
│   code: 'ENOENT',
│   syscall: 'spawnSync E:\\Files\\sodium-alice\\node_modules\\.pnpm\\github.com+MercuryWorkshop+dreamland-router@017…
│   path: 'E:\\Files\\sodium-alice\\node_modules\\.pnpm\\github.com+MercuryWorkshop+dreamland-router@017f5668b6289ea0…
│   spawnargs: [ '--version' ],
│   error: [Circular *1],
│   status: null,
│   signal: null,
│   output: null,
│   pid: 0,
│   stdout: null,
│   stderr: null
│ }
│ Node.js v18.17.1
│     at checkExecSyncError (node:child_process:885:11)
│     at Object.execFileSync (node:child_process:921:15)
│     at validateBinaryVersion (E:\Files\sodium-alice\node_modules\.pnpm\github.com+MercuryWorkshop+dreamland-router@…
│     at E:\Files\sodium-alice\node_modules\.pnpm\github.com+MercuryWorkshop+dreamland-router@017f5668b6289ea071ea7ba…
│   status: 1,
│   signal: null,
│   output: [
│     null,
│     Buffer(0) [Uint8Array] [],
│     Buffer(2034) [Uint8Array] [
│       110, 111, 100, 101,  58,  99, 104, 105, 108, 100,  95, 112,
│       114, 111,  99, 101, 115, 115,  58,  57,  50,  52,  13,  10,
│        32,  32,  32,  32, 116, 104, 114, 111, 119,  32, 101, 114,
│       114,  59,  13,  10,  32,  32,  32,  32,  94,  13,  10,  13,
│        10,  60, 114, 101, 102,  32,  42,  49,  62,  32,  69, 114,
│       114, 111, 114,  58,  32, 115, 112,  97, 119, 110,  83, 121,
│       110,  99,  32,  69,  58,  92,  70, 105, 108, 101, 115,  92,
│       115, 111, 100, 105, 117, 109,  45,  97, 108, 105,  99, 101,
│        92, 110, 111, 100,
│       ... 1934 more items
│     ]
│   ],
│   pid: 8356,
│   stdout: Buffer(0) [Uint8Array] [],
│   stderr: Buffer(2034) [Uint8Array] [
│     110, 111, 100, 101,  58,  99, 104, 105, 108, 100,  95, 112,
│     114, 111,  99, 101, 115, 115,  58,  57,  50,  52,  13,  10,
│      32,  32,  32,  32, 116, 104, 114, 111, 119,  32, 101, 114,
│     114,  59,  13,  10,  32,  32,  32,  32,  94,  13,  10,  13,
│      10,  60, 114, 101, 102,  32,  42,  49,  62,  32,  69, 114,
│     114, 111, 114,  58,  32, 115, 112,  97, 119, 110,  83, 121,
│     110,  99,  32,  69,  58,  92,  70, 105, 108, 101, 115,  92,
│     115, 111, 100, 105, 117, 109,  45,  97, 108, 105,  99, 101,
│      92, 110, 111, 100,
│     ... 1934 more items
│   ]
│ }
│ Node.js v18.17.1
└─ Failed in 161ms at E:\Files\sodium-alice\node_modules\dreamland-router\node_modules\.pnpm\esbuild@0.20.0\node_modules\esbuild
 ELIFECYCLE  Command failed with exit code 1.